### PR TITLE
Add MAX_UPLOAD_SIZE_MB env var

### DIFF
--- a/config/config.spec.js
+++ b/config/config.spec.js
@@ -1,0 +1,68 @@
+const Config = require('./index');
+const expect = require('chai').expect;
+
+const previousEnv = Object.assign({}, process.env);
+
+describe('Config', function () {
+
+    const defaultTestEnv = {
+        BUCKET_NAME: 'cf-epic-test',
+        CF_API_KEY: 'apiKey',
+        CF_BRANCH_TAG_NORMALIZED: 'master',
+        CF_BUILD_ID: '65118d2ea9534620832679c9',
+        CF_STORAGE_INTEGRATION: 'epicgoogle',
+        REPORT_TYPE: '1',
+        REPORT_DIR: 'coverage_data/unified_coverage_reports/html',
+        REPORT_INDEX_FILE: 'index.html',
+    };
+
+    this.timeout(20000);
+
+    afterEach(() => {
+        process.env = previousEnv;
+    });
+
+    it('should set maxUploadSize to value from MAX_UPLOAD_SIZE_MB as number type', async () => {
+        process.env = {
+            ...defaultTestEnv,
+            MAX_UPLOAD_SIZE_MB: '1234567890'
+        };
+
+        const result = Config.getSingleConfig();
+
+        expect(result.maxUploadSize).to.equal(1234567890);
+    });
+
+    it('should set maxUploadSize to 1000 if MAX_UPLOAD_SIZE_MB is not a number', async () => {
+        process.env = {
+            ...defaultTestEnv,
+            MAX_UPLOAD_SIZE_MB: 'not-a-number'
+        };
+
+        const result = Config.getSingleConfig();
+
+        expect(result.maxUploadSize).to.equal(1000);
+    });
+
+    it('should set maxUploadSize to 1000 if MAX_UPLOAD_SIZE_MB is not set', async () => {
+        process.env = {
+            ...defaultTestEnv,
+            REPORT_INDEX_FILE: 'index.html',
+        };
+
+        const result = Config.getSingleConfig();
+
+        expect(result.maxUploadSize).to.equal(1000);
+    });
+
+    it('should set maxUploadSize to the rounded down value of MAX_UPLOAD_SIZE_MB if it is not an integer', async () => {
+        process.env = {
+            ...defaultTestEnv,
+            MAX_UPLOAD_SIZE_MB: '123.789'
+        };
+
+        const result = Config.getSingleConfig();
+
+        expect(result.maxUploadSize).to.equal(123);
+    });
+});

--- a/config/config.spec.js
+++ b/config/config.spec.js
@@ -22,47 +22,40 @@ describe('Config', function () {
         process.env = previousEnv;
     });
 
-    it('should set maxUploadSize to value from MAX_UPLOAD_SIZE_MB as number type', async () => {
-        process.env = {
-            ...defaultTestEnv,
-            MAX_UPLOAD_SIZE_MB: '1234567890'
+    const testEnvVar = (varName, outputGetter, input, expected) =>
+        function () {
+            process.env = defaultTestEnv;
+
+            if (input) {
+                process.env[varName] = input;
+            }
+
+            const result = Config.getSingleConfig();
+
+            expect(outputGetter(result)).to.equal(expected);
         };
 
-        const result = Config.getSingleConfig();
+    it('should set maxUploadSize to value from MAX_UPLOAD_SIZE_MB as number type',
+        testEnvVar('MAX_UPLOAD_SIZE_MB', result => result.maxUploadSize, '1234567890', 1234567890));
 
-        expect(result.maxUploadSize).to.equal(1234567890);
-    });
+    it('should set maxUploadSize to 1000 if MAX_UPLOAD_SIZE_MB is not a number',
+        testEnvVar('MAX_UPLOAD_SIZE_MB', result => result.maxUploadSize, 'not-a-number', 1000));
 
-    it('should set maxUploadSize to 1000 if MAX_UPLOAD_SIZE_MB is not a number', async () => {
-        process.env = {
-            ...defaultTestEnv,
-            MAX_UPLOAD_SIZE_MB: 'not-a-number'
-        };
+    it('should set maxUploadSize to 1000 if MAX_UPLOAD_SIZE_MB is not set',
+        testEnvVar('REPORT_INDEX_FILE', result => result.maxUploadSize, 'index.html', 1000));
 
-        const result = Config.getSingleConfig();
+    it('should set maxUploadSize to the rounded down value of MAX_UPLOAD_SIZE_MB if it is not an integer',
+        testEnvVar('MAX_UPLOAD_SIZE_MB', result => result.maxUploadSize, '123.789', 123));
 
-        expect(result.maxUploadSize).to.equal(1000);
-    });
+    it('should set retriesForCodefreshAPI to value from CF_API_RETRIES as number type',
+        testEnvVar('CF_API_RETRIES', result => result.env.retriesForCodefreshAPI, '5', 5));
 
-    it('should set maxUploadSize to 1000 if MAX_UPLOAD_SIZE_MB is not set', async () => {
-        process.env = {
-            ...defaultTestEnv,
-            REPORT_INDEX_FILE: 'index.html',
-        };
+    it('should set retriesForCodefreshAPI to 1000 if CF_API_RETRIES is not a number',
+        testEnvVar('CF_API_RETRIES', result => result.env.retriesForCodefreshAPI, 'not-a-number', 0));
 
-        const result = Config.getSingleConfig();
+    it('should set retriesForCodefreshAPI to 1000 if CF_API_RETRIES is not set',
+        testEnvVar('REPORT_INDEX_FILE', result => result.env.retriesForCodefreshAPI, 'index.html', 0));
 
-        expect(result.maxUploadSize).to.equal(1000);
-    });
-
-    it('should set maxUploadSize to the rounded down value of MAX_UPLOAD_SIZE_MB if it is not an integer', async () => {
-        process.env = {
-            ...defaultTestEnv,
-            MAX_UPLOAD_SIZE_MB: '123.789'
-        };
-
-        const result = Config.getSingleConfig();
-
-        expect(result.maxUploadSize).to.equal(123);
-    });
+    it('should set retriesForCodefreshAPI to the rounded down value of CF_API_RETRIES if it is not an integer',
+        testEnvVar('CF_API_RETRIES', result => result.env.retriesForCodefreshAPI, '123.789', 123));
 });

--- a/config/configUtils.spec.js
+++ b/config/configUtils.spec.js
@@ -1,6 +1,4 @@
 const expect = require('chai').expect;
-const proxyquire = require('proxyquire');
-const sinon = require('sinon');
 const ConfigUtils = require('./ConfigUtils');
 
 const testEnv = Object.assign({}, process.env);
@@ -21,10 +19,11 @@ describe('ConfigUtils', function () {
             CF_BUILD_ID: '65118d2ea9534620832679c9',
             CF_STORAGE_INTEGRATION: 'epicgoogle',
         };
-        for (let i=0; i<=150; i+=1) {
-            env[`REPORT_TYPE.${i}`]=`${i}`;
-            env[`REPORT_DIR.${i}`]=`coverage_data/unified_coverage_reports/${i}/html`;
-            env[`REPORT_INDEX_FILE.${i}`]='index.html';
+        for (let i = 0; i <= 150; i += 1) {
+            env[`REPORT_TYPE.${i}`] = `${i}`;
+            env[`REPORT_DIR.${i}`] = `coverage_data/unified_coverage_reports/${i}/html`;
+            env[`REPORT_INDEX_FILE.${i}`] = 'index.html';
+            env[`MAX_UPLOAD_SIZE_MB.${i}`] = `${i * 10}`;
         }
 
         const uploadVars = ['REPORT_DIR',
@@ -32,10 +31,11 @@ describe('ConfigUtils', function () {
             'REPORT_INDEX_FILE',
             'ALLURE_DIR',
             'CLEAR_TEST_REPORT',
-            'REPORT_TYPE'];
+            'REPORT_TYPE',
+            'MAX_UPLOAD_SIZE_MB'];
 
         process.env = env;
-        const result = ConfigUtils.getMultiReportUpload(uploadVars)
+        const result = ConfigUtils.getMultiReportUpload(uploadVars);
         expect(result.length).to.equal(151);
     });
 

--- a/config/index.js
+++ b/config/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const path = require('path');
 const _ = require('lodash');
 const ConfigUtils = require('./ConfigUtils');
@@ -81,7 +79,7 @@ class Config {
         const apiHost = ConfigUtils.buildApiHost();
         const _reportWrapDir = _.isNumber(reportWrapDir) ? String(reportWrapDir) : '';
         const maxUploadSizeMbInteger = parseInt(maxUploadSizeMb, 10);
-        const _maxUploadSizeMb = _.isNaN(maxUploadSizeMbInteger) ? 1000 : maxUploadSizeMb;
+        const _maxUploadSizeMb = _.isNaN(maxUploadSizeMbInteger) ? 1000 : maxUploadSizeMbInteger;
         /**
          * field uploadMaxSize set by SingleReportRunner, value in MB
          */

--- a/config/index.js
+++ b/config/index.js
@@ -40,6 +40,7 @@ class Config {
 
         UPLOAD_ARRAY_VARS.forEach((uploadVar) => {
             if (process.env[uploadVar]) {
+                console.log('scme single varName', uploadVar, _.camelCase(uploadVar), process.env[uploadVar]);
                 normalisedEnv[_.camelCase(uploadVar)] = process.env[uploadVar];
             }
         });
@@ -54,6 +55,7 @@ class Config {
             const normalisedEnv = {};
 
             Object.keys(env).forEach((varName) => {
+                console.log('scme multi varName', varName, _.camelCase(varName), env[varName]);
                 normalisedEnv[_.camelCase(varName)] = env[varName];
             });
 
@@ -80,7 +82,9 @@ class Config {
         } = env;
         const apiHost = ConfigUtils.buildApiHost();
         const _reportWrapDir = _.isNumber(reportWrapDir) ? String(reportWrapDir) : '';
+        console.log('scme maxUploadSizeMb', maxUploadSizeMb);
         const _maxUploadSizeMb = _.isNumber(maxUploadSizeMb) ? maxUploadSizeMb : 1000;
+        console.log('scme _maxUploadSizeMb', _maxUploadSizeMb);
         /**
          * field uploadMaxSize set by SingleReportRunner, value in MB
          */

--- a/config/index.js
+++ b/config/index.js
@@ -7,7 +7,15 @@ const ConfigUtils = require('./ConfigUtils');
 /**
  * arrayVars - customer can define array of this vars for upload multiple reports, for example REPORT_DIR.0
  */
-const UPLOAD_ARRAY_VARS = ['REPORT_DIR', 'REPORT_PATH', 'REPORT_INDEX_FILE', 'ALLURE_DIR', 'CLEAR_TEST_REPORT', 'REPORT_TYPE'];
+const UPLOAD_ARRAY_VARS = [
+    'REPORT_DIR',
+    'REPORT_PATH',
+    'REPORT_INDEX_FILE',
+    'ALLURE_DIR',
+    'CLEAR_TEST_REPORT',
+    'REPORT_TYPE',
+    'MAX_UPLOAD_SIZE_MB'
+];
 
 const INFO = 'info';
 const DEBUG = 'debug';
@@ -68,9 +76,11 @@ class Config {
             reportType,
             reportWrapDir,
             reportPath,
+            maxUploadSizeMb
         } = env;
         const apiHost = ConfigUtils.buildApiHost();
         const _reportWrapDir = _.isNumber(reportWrapDir) ? String(reportWrapDir) : '';
+        const _maxUploadSizeMb = _.isNumber(maxUploadSizeMb) ? maxUploadSizeMb : 1000;
         /**
          * field uploadMaxSize set by SingleReportRunner, value in MB
          */
@@ -95,7 +105,7 @@ class Config {
             annotationName: 'cf_test_reporter_link',
             reportsIndexDir: `${path.dirname(require.resolve('../_reportsIndex_'))}`,
             uploadArrayVars: UPLOAD_ARRAY_VARS,
-            maxUploadSize: 1000,
+            maxUploadSize: _maxUploadSizeMb,
             env: {
                 // bucketName - only bucket name, with out subdir path
                 bucketName: ConfigUtils.getBucketName(),

--- a/config/index.js
+++ b/config/index.js
@@ -40,7 +40,6 @@ class Config {
 
         UPLOAD_ARRAY_VARS.forEach((uploadVar) => {
             if (process.env[uploadVar]) {
-                console.log('scme single varName', uploadVar, _.camelCase(uploadVar), process.env[uploadVar]);
                 normalisedEnv[_.camelCase(uploadVar)] = process.env[uploadVar];
             }
         });
@@ -55,7 +54,6 @@ class Config {
             const normalisedEnv = {};
 
             Object.keys(env).forEach((varName) => {
-                console.log('scme multi varName', varName, _.camelCase(varName), env[varName]);
                 normalisedEnv[_.camelCase(varName)] = env[varName];
             });
 
@@ -82,11 +80,8 @@ class Config {
         } = env;
         const apiHost = ConfigUtils.buildApiHost();
         const _reportWrapDir = _.isNumber(reportWrapDir) ? String(reportWrapDir) : '';
-        const maxUploadSizeMbNumber = parseInt(maxUploadSizeMb, 10);
-        console.log('scme maxUploadSizeMb', maxUploadSizeMb);
-        console.log('scme maxUploadSizeMbNumber', maxUploadSizeMbNumber);
-        const _maxUploadSizeMb = _.isNaN(maxUploadSizeMbNumber) ? 1000 : maxUploadSizeMb;
-        console.log('scme _maxUploadSizeMb', _maxUploadSizeMb);
+        const maxUploadSizeMbInteger = parseInt(maxUploadSizeMb, 10);
+        const _maxUploadSizeMb = _.isNaN(maxUploadSizeMbInteger) ? 1000 : maxUploadSizeMb;
         /**
          * field uploadMaxSize set by SingleReportRunner, value in MB
          */

--- a/config/index.js
+++ b/config/index.js
@@ -82,8 +82,10 @@ class Config {
         } = env;
         const apiHost = ConfigUtils.buildApiHost();
         const _reportWrapDir = _.isNumber(reportWrapDir) ? String(reportWrapDir) : '';
+        const maxUploadSizeMbNumber = parseInt(maxUploadSizeMb, 10);
         console.log('scme maxUploadSizeMb', maxUploadSizeMb);
-        const _maxUploadSizeMb = _.isNumber(maxUploadSizeMb) ? maxUploadSizeMb : 1000;
+        console.log('scme maxUploadSizeMbNumber', maxUploadSizeMbNumber);
+        const _maxUploadSizeMb = _.isNaN(maxUploadSizeMbNumber) ? 1000 : maxUploadSizeMb;
         console.log('scme _maxUploadSizeMb', _maxUploadSizeMb);
         /**
          * field uploadMaxSize set by SingleReportRunner, value in MB

--- a/config/index.js
+++ b/config/index.js
@@ -12,7 +12,8 @@ const UPLOAD_ARRAY_VARS = [
     'ALLURE_DIR',
     'CLEAR_TEST_REPORT',
     'REPORT_TYPE',
-    'MAX_UPLOAD_SIZE_MB'
+    'MAX_UPLOAD_SIZE_MB',
+    'CF_API_RETRIES'
 ];
 
 const INFO = 'info';
@@ -74,12 +75,13 @@ class Config {
             reportType,
             reportWrapDir,
             reportPath,
-            maxUploadSizeMb
+            maxUploadSizeMb,
+            cfApiRetries
         } = env;
         const apiHost = ConfigUtils.buildApiHost();
         const _reportWrapDir = _.isNumber(reportWrapDir) ? String(reportWrapDir) : '';
-        const maxUploadSizeMbInteger = parseInt(maxUploadSizeMb, 10);
-        const _maxUploadSizeMb = _.isNaN(maxUploadSizeMbInteger) ? 1000 : maxUploadSizeMbInteger;
+        const _maxUploadSizeMb = parseInt(maxUploadSizeMb, 10) || 1000;
+        const _cfApiRetries = parseInt(cfApiRetries, 10) || 0;
         /**
          * field uploadMaxSize set by SingleReportRunner, value in MB
          */
@@ -118,7 +120,7 @@ class Config {
                 branchNormalized: process.env.CF_BRANCH_TAG_NORMALIZED,
                 storageIntegration: process.env.CF_STORAGE_INTEGRATION,
                 logLevel: logLevelsMap[process.env.REPORT_LOGGING_LEVEL] || INFO,
-                retriesForCodefreshAPI: Number(process.env.CF_API_RETRIES) || 0,
+                retriesForCodefreshAPI: _cfApiRetries,
                 sourceReportFolderName: (allureDir || 'allure-results').trim(),
                 reportDir: ((reportDir || '').trim()) || undefined,
                 reportPath: ((reportPath || '').trim()).replace(/\/$/, ''),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cf-docker-test-reporting",
-	"version": "1.0.7",
+	"version": "2.0.0",
 	"description": "Generate test report",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cf-docker-test-reporting",
-	"version": "2.0.0",
+	"version": "1.2.0",
 	"description": "Generate test report",
 	"repository": {
 		"type": "git",

--- a/src/validation/index.js
+++ b/src/validation/index.js
@@ -14,7 +14,7 @@ class Validator {
         }
 
         if (config.uploadMaxSize < await FileManager.getDirOrFileSize(pathToDir)) {
-            throw new Error(`Error: Directory for upload is to large, max size is ${config.uploadMaxSize} MB`);
+            throw new Error(`Error: Directory for upload is too large, max size is ${config.uploadMaxSize} MB`);
         }
 
         return true;
@@ -30,7 +30,7 @@ class Validator {
         }
 
         if (config.uploadMaxSize < await FileManager.getDirOrFileSize(pathToFile)) {
-            throw new Error(`Error: File for upload is to large, max size is ${config.uploadMaxSize} MB`);
+            throw new Error(`Error: File for upload is too large, max size is ${config.uploadMaxSize} MB`);
         }
 
         return true;

--- a/src/validation/validation.spec.js
+++ b/src/validation/validation.spec.js
@@ -91,7 +91,7 @@ describe('Validation', () => {
                 await Vld.validateUploadDir({ config: { ...config, uploadMaxSize: 0.0001 } }, pathToDir);
                 expect.fali(false, false, 'must throw err when dir more than uploadMaxSize');
             } catch (e) {
-                expect(e.message.includes('Directory for upload is to large')).to.equal(true);
+                expect(e.message.includes('Directory for upload is too large')).to.equal(true);
             }
 
             await FileManager.removeResource(pathToDir);
@@ -140,7 +140,7 @@ describe('Validation', () => {
                 });
                 expect.fali(false, false, 'must throw err when file more than uploadMaxSize');
             } catch (e) {
-                expect(e.message.includes('File for upload is to large')).to.equal(true);
+                expect(e.message.includes('File for upload is too large')).to.equal(true);
             }
 
             fs.unlinkSync(pathToFile);


### PR DESCRIPTION
# Background

The max upload size is currently hard-coded to 1000MB which is not always enough. We're adding an argument so that the user can specify a max upload size.

[Jira Ticket](https://codefresh-io.atlassian.net/browse/CR-19339?atlOrigin=eyJpIjoiMTM0YzVhNTdiZWRhNGI2Nzg2M2Y4ZmFlOTQ0ZjYyOGUiLCJwIjoiaiJ9)

# Results

As well as adding some basic input tests for the Config class, I've manually tested this using a slightly modified/updated `test-reporting` step in Codefresh. I was able to upload a mocha test report with a 5MB file added to the assets folder when I either set the value of the `max_upload_size_mb` to something higher than 6MB or if I don't set it. When I set the value to something lower than 6MB, the step fails because the upload goes over the maximum.

# Screenshot

_I set the max upload size value to 4MB which I expected to fail the step_
<img width="922" alt="Screenshot 2024-08-30 at 10 22 19" src="https://github.com/user-attachments/assets/686a459c-6659-417a-897a-c02e084f2b2f">

